### PR TITLE
feat(ui): sprint-2 complete

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,10 +1,12 @@
 export const metadata = { title: 'Sofa Configurator', description: 'Конфигуратор диванов' };
 import '../styles/globals.css';
 
+import Providers from './providers';
+
 export default function RootLayout({children}:{children:React.ReactNode}){
   return (
     <html lang="ru">
-      <body>{children}</body>
+      <body><Providers>{children}</Providers></body>
     </html>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,69 +1,57 @@
+'use client';
+
 import Image from 'next/image';
+import { useEffect, useMemo, useState } from 'react';
+import ModelCarousel, { type Model } from '@/components/carousel/ModelCarousel';
+import OptionsPanel, { type Accessory } from '@/components/options/OptionsPanel';
+import ModuleGrid from '@/components/grid/ModuleGrid';
+import ActionBar from '@/components/actions/ActionBar';
+import AssemblyCanvas from '@/components/assembly/AssemblyCanvas';
+import ChosenList from '@/components/chosen/ChosenList';
+import type { ModuleSpec, CompatibilityRule } from '@/packages/rules';
+import { useI18n } from '@/lib/i18n';
 
 export default function Page(){
+  const [lang,setLang] = useState<'ru'|'kz'|'hy'>('ru');
+  const { t } = useI18n(lang);
+  const [models,setModels] = useState<Model[]>([]);
+  const [modules,setModules] = useState<ModuleSpec[]>([]);
+  const [rules,setRules] = useState<CompatibilityRule[]>([]);
+  const [accessories,setAccessories] = useState<Accessory[]>([]);
+
+  useEffect(() => {
+    fetch('/mock/models.json').then(r=>r.json()).then(setModels);
+    fetch('/mock/modules.json').then(r=>r.json()).then(setModules);
+    fetch('/mock/rules.json').then(r=>r.json()).then(setRules);
+    fetch('/mock/accessories.json').then(r=>r.json()).then(setAccessories);
+  }, []);
+
+  const modulesById = useMemo(() => Object.fromEntries(modules.map(m=>[m.id,m])), [modules]);
+  const accessoriesById = useMemo(() => Object.fromEntries(accessories.map(a=>[a.id,a])), [accessories]);
+
   return (
     <main className="grid" style={{gridTemplateRows:'12vh calc(100vh - 12vh)'}}>
-      {/* Карусель моделей */}
       <header className="flex items-center justify-between px-4">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 overflow-hidden">
           <Image src="/brand/destyle_gray_alfa.png" alt="brand" width={120} height={30}/>
-          <h1 className="text-lg text-gray-700">Конфигуратор</h1>
+          <ModelCarousel models={models}/>
         </div>
-        <div className="text-sm text-gray-600">RU | KZ | HY</div>
+        <div className="text-sm text-gray-600 flex gap-2">
+          {['ru','kz','hy'].map(l => (
+            <button key={l} className={lang===l?"font-bold":''} onClick={()=>setLang(l as any)}>{l.toUpperCase()}</button>
+          ))}
+        </div>
       </header>
 
-      {/* Три колонки 20/40/40 */}
       <section className="grid" style={{gridTemplateColumns:'20vw 40vw 40vw', height:'100%'}}>
-        {/* Левая колонка */}
+        <div className="h-full border-r"><OptionsPanel accessories={accessories} t={t}/></div>
         <div className="grid" style={{gridTemplateRows:'1fr 10%'}}>
-          <div className="p-3">
-            <h2 className="font-semibold mb-2">Параметры</h2>
-            <div className="space-y-2 text-sm text-gray-700">
-              <div>Ткань / Цвет</div>
-              <div>Ножки / Цвет</div>
-              <div>Аксессуары (пуф/кресло/подушки)</div>
-            </div>
-          </div>
-          <div className="p-3">
-            <button className="w-full py-2 rounded text-white" style={{background:'var(--brand-red)'}} disabled>
-              Скачать (неактивно)
-            </button>
-          </div>
+          <div className="p-3 overflow-auto"><ModuleGrid modules={modules} rules={rules} modulesById={modulesById}/></div>
+          <div className="p-3"><ActionBar modulesById={modulesById} t={t}/></div>
         </div>
-
-        {/* Центр */}
-        <div className="grid" style={{gridTemplateRows:'1fr 10%'}}>
-          <div className="p-3">
-            <h2 className="font-semibold mb-2">Доступные модули</h2>
-            <div className="grid grid-cols-3 gap-2">
-              <div className="border rounded p-2 text-sm">KSL_2</div>
-              <div className="border rounded p-2 text-sm">CORNER_L</div>
-              <div className="border rounded p-2 text-sm">KSR_2</div>
-            </div>
-          </div>
-          <div className="p-3 flex gap-2">
-            <button className="px-3 py-2 rounded bg-blue-600 text-white opacity-50" disabled>Отмена</button>
-            <div className="text-sm text-gray-600 flex items-center">Добавьте модули слева направо</div>
-          </div>
-        </div>
-
-        {/* Правая колонка */}
         <div className="grid" style={{gridTemplateRows:'1fr 1fr'}}>
-          <div className="relative p-3">
-            <div className="absolute right-4 top-4 text-sm text-gray-700 bg-white/70 px-2 py-1 rounded">
-              Ш×Г: 0×0 мм · Места: 0
-            </div>
-            <div className="h-full w-full rounded border border-gray-300 bg-gray-100 flex items-center justify-center text-gray-500">
-              SVG‑сцена (пан/зум)
-            </div>
-          </div>
-          <div className="p-3">
-            <h2 className="font-semibold mb-2">Выбранные модули</h2>
-            <table className="w-full text-sm">
-              <thead><tr className="text-left text-gray-600"><th>№</th><th>SKU</th><th>Название</th><th>Размеры</th><th>Места</th></tr></thead>
-              <tbody><tr><td colSpan={5} className="text-center py-4 text-gray-500">Пока пусто</td></tr></tbody>
-            </table>
-          </div>
+          <div className="p-3"><AssemblyCanvas modulesById={modulesById} accessoriesById={accessoriesById}/></div>
+          <ChosenList modulesById={modulesById}/>
         </div>
       </section>
     </main>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { Provider } from 'react-redux';
+import { store } from '@/features/store';
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <Provider store={store}>{children}</Provider>;
+}

--- a/components/actions/ActionBar.tsx
+++ b/components/actions/ActionBar.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useAppDispatch, useAppSelector } from '@/features/hooks';
+import { undo } from '@/features/builder/builderSlice';
+import type { ModuleSpec } from '@/packages/rules';
+
+export default function ActionBar({ modulesById, t }:{ modulesById: Record<string, ModuleSpec>; t:(k:string)=>string; }){
+  const dispatch = useAppDispatch();
+  const { chain, isComplete } = useAppSelector(s => s.builder);
+  const disabled = chain.length === 0;
+  let hint = '';
+  if(chain.length === 0) hint = 'Добавьте первый модуль (левый глухой торец)';
+  else if(!isComplete) hint = 'Добавьте правую секцию с глухим торцом';
+  return (
+    <div className="flex gap-2">
+      <button
+        className={`px-3 py-2 rounded bg-blue-600 text-white ${disabled?'opacity-50':''}`}
+        disabled={disabled}
+        onClick={() => dispatch(undo({specs: modulesById}))}
+      >
+        {t('undo')}
+      </button>
+      <div className="text-sm text-gray-600 flex items-center">{hint}</div>
+    </div>
+  );
+}

--- a/components/assembly/AssemblyCanvas.tsx
+++ b/components/assembly/AssemblyCanvas.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useAppDispatch, useAppSelector } from '@/features/hooks';
+import { moveAccessory } from '@/features/builder/builderSlice';
+import type { ModuleSpec } from '@/packages/rules';
+
+interface Accessory { id:string; imageUrl:string; }
+
+interface Props {
+  modulesById: Record<string, ModuleSpec>;
+  accessoriesById: Record<string, Accessory>;
+}
+
+export default function AssemblyCanvas({ modulesById, accessoriesById }: Props){
+  const dispatch = useAppDispatch();
+  const { placed, freeItems, totalSize, totalSeats, fitToView:fit } = useAppSelector(s=>s.builder);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [view, setView] = useState({x:0,y:0,scale:0.5});
+  const [panStart, setPanStart] = useState<{x:number;y:number}|null>(null);
+  const [dragAcc, setDragAcc] = useState<string|null>(null);
+
+  // fit to view when requested
+  useEffect(()=>{
+    if(placed.length===0){ setView({x:0,y:0,scale:0.5}); return; }
+    const bbox = {minX:Infinity,minY:Infinity,maxX:-Infinity,maxY:-Infinity};
+    for(const p of placed){
+      const spec = modulesById[p.moduleId];
+      const rot = p.rotation % 180 !== 0;
+      const w = rot ? spec.bbox.depth : spec.bbox.width;
+      const h = rot ? spec.bbox.width : spec.bbox.depth;
+      bbox.minX = Math.min(bbox.minX, p.x);
+      bbox.minY = Math.min(bbox.minY, p.y);
+      bbox.maxX = Math.max(bbox.maxX, p.x + w);
+      bbox.maxY = Math.max(bbox.maxY, p.y + h);
+    }
+    const width = bbox.maxX - bbox.minX;
+    const height = bbox.maxY - bbox.minY;
+    const container = containerRef.current;
+    if(container){
+      const scale = Math.min(container.clientWidth/width, container.clientHeight/height, 3);
+      const x = (container.clientWidth - width*scale)/2 - bbox.minX*scale;
+      const y = (container.clientHeight - height*scale)/2 - bbox.minY*scale;
+      setView({x,y,scale});
+    }
+  }, [fit, placed, modulesById]);
+
+  const onWheel = (e:React.WheelEvent) => {
+    e.preventDefault();
+    setView(v=>{
+      let scale = v.scale * (e.deltaY < 0 ? 1.1 : 0.9);
+      scale = Math.min(3, Math.max(0.5, scale));
+      return {...v, scale};
+    });
+  };
+
+  const onPointerDown = (e:React.PointerEvent) => {
+    const target = e.target as HTMLElement;
+    const id = target.getAttribute('data-acc');
+    if(id){
+      setDragAcc(id);
+    }else{
+      setPanStart({x:e.clientX - view.x, y:e.clientY - view.y});
+    }
+  };
+
+  const onPointerMove = (e:React.PointerEvent) => {
+    if(dragAcc){
+      const rect = containerRef.current!.getBoundingClientRect();
+      const x = (e.clientX - rect.left - view.x)/view.scale;
+      const y = (e.clientY - rect.top - view.y)/view.scale;
+      dispatch(moveAccessory({id:dragAcc,x,y}));
+    }else if(panStart){
+      setView(v=>({...v, x:e.clientX - panStart.x, y:e.clientY - panStart.y}));
+    }
+  };
+
+  const stopDrag = () => { setPanStart(null); setDragAcc(null); };
+
+  return (
+    <div ref={containerRef} className="relative w-full h-full bg-gray-100 overflow-hidden" onWheel={onWheel} onPointerMove={onPointerMove} onPointerUp={stopDrag} onPointerLeave={stopDrag} onPointerDown={onPointerDown}>
+      <svg className="absolute inset-0 w-full h-full touch-none">
+        <g transform={`translate(${view.x} ${view.y}) scale(${view.scale})`}>
+          {placed.map((p,i)=>{
+            const spec = modulesById[p.moduleId];
+            const rot = p.rotation % 180 !== 0;
+            const w = rot ? spec.bbox.depth : spec.bbox.width;
+            const h = rot ? spec.bbox.width : spec.bbox.depth;
+            return <rect key={i} x={p.x} y={p.y} width={w} height={h} fill="#eee" stroke="var(--brand-gray)" />;
+          })}
+          {freeItems.map(f=>{
+            const acc = accessoriesById[f.accessoryId];
+            if(!acc) return null;
+            return <image key={f.id} data-acc={f.id} href={acc.imageUrl} x={f.x} y={f.y} width={80} height={80}/>;
+          })}
+        </g>
+      </svg>
+      <div className="absolute right-4 top-4 text-sm text-gray-700 bg-white/70 px-2 py-1 rounded">
+        {`Ш×Г: ${totalSize.width}×${totalSize.depth} мм · Места: ${totalSeats}`}
+      </div>
+    </div>
+  );
+}

--- a/components/carousel/ModelCarousel.tsx
+++ b/components/carousel/ModelCarousel.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import Image from 'next/image';
+import { useAppDispatch, useAppSelector } from '@/features/hooks';
+import { selectModel } from '@/features/builder/builderSlice';
+
+export interface Model { id: string; name: string; thumbUrl: string; }
+
+export default function ModelCarousel({ models }: { models: Model[] }) {
+  const dispatch = useAppDispatch();
+  const current = useAppSelector(s => s.builder.modelId);
+  return (
+    <div className="flex gap-3 overflow-x-auto py-2">
+      {models.map(m => (
+        <button
+          key={m.id}
+          onClick={() => dispatch(selectModel(m.id))}
+          className={`flex flex-col items-center ${current===m.id?'opacity-100':'opacity-60'}`}
+        >
+          <Image src={m.thumbUrl} alt={m.name} width={80} height={40} />
+          <span className="text-xs mt-1">{m.name}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/chosen/ChosenList.tsx
+++ b/components/chosen/ChosenList.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useAppSelector } from '@/features/hooks';
+import type { ModuleSpec } from '@/packages/rules';
+
+export default function ChosenList({ modulesById }:{ modulesById: Record<string, ModuleSpec>; }){
+  const { chain, totalSeats } = useAppSelector(s=>s.builder);
+  return (
+    <div className="p-3">
+      <h2 className="font-semibold mb-2">Выбранные модули</h2>
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="text-left text-gray-600"><th>№</th><th>SKU</th><th>Название</th><th>Размеры</th><th>Места</th></tr>
+        </thead>
+        <tbody>
+          {chain.length === 0 && (
+            <tr><td colSpan={5} className="text-center py-4 text-gray-500">Пока пусто</td></tr>
+          )}
+          {chain.map((id,idx)=>{
+            const m = modulesById[id];
+            if(!m) return null;
+            return (
+              <tr key={idx} className="border-t">
+                <td>{idx+1}</td>
+                <td>{m.sku}</td>
+                <td>{m.name}</td>
+                <td>{m.bbox.width}×{m.bbox.depth}</td>
+                <td>{m.seatCount ?? 0}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+        {chain.length>0 && (
+          <tfoot>
+            <tr className="border-t font-semibold"><td colSpan={4} className="text-right">Итого</td><td>{totalSeats}</td></tr>
+          </tfoot>
+        )}
+      </table>
+    </div>
+  );
+}

--- a/components/grid/ModuleGrid.tsx
+++ b/components/grid/ModuleGrid.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Image from 'next/image';
+import { useAppDispatch, useAppSelector } from '@/features/hooks';
+import { addModule } from '@/features/builder/builderSlice';
+import { getAvailableNextModules, type ModuleSpec, type CompatibilityRule } from '@/packages/rules';
+
+interface Props {
+  modules: ModuleSpec[];
+  rules: CompatibilityRule[];
+  modulesById: Record<string, ModuleSpec>;
+}
+
+export default function ModuleGrid({ modules, rules, modulesById }: Props){
+  const dispatch = useAppDispatch();
+  const builder = useAppSelector(s => s.builder);
+  const available = getAvailableNextModules(builder, modules, rules);
+  return (
+    <div className="grid grid-cols-3 gap-2">
+      {available.map(m => (
+        <button
+          key={m.id}
+          className="border rounded p-2 text-sm flex flex-col items-center"
+          onClick={() => dispatch(addModule({spec:m, specs:modulesById}))}
+        >
+          <Image src={m.images.thumbUrl} alt={m.name} width={80} height={40}/>
+          <span className="mt-1 text-center">{m.short}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/options/OptionsPanel.tsx
+++ b/components/options/OptionsPanel.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Image from 'next/image';
+import { useAppDispatch, useAppSelector } from '@/features/hooks';
+import { addAccessory, removeAccessory } from '@/features/builder/builderSlice';
+
+export interface Accessory { id: string; name: string; imageUrl: string; }
+
+export default function OptionsPanel({ accessories, t }:{ accessories: Accessory[]; t:(k:string)=>string; }){
+  const dispatch = useAppDispatch();
+  const freeItems = useAppSelector(s => s.builder.freeItems);
+  const isComplete = useAppSelector(s => s.builder.isComplete);
+  const count = (id:string) => freeItems.filter(f => f.accessoryId===id).length;
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex-1 space-y-4">
+        <div className="space-y-2">
+          <select className="w-full border rounded p-1 text-sm"><option>Ткань</option></select>
+          <select className="w-full border rounded p-1 text-sm"><option>Ножки</option></select>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-2 text-sm">{t('accessories')}</h3>
+          <div className="flex flex-col gap-2">
+            {accessories.map(a => (
+              <div key={a.id} className="flex items-center justify-between text-sm">
+                <div className="flex items-center gap-2">
+                  <Image src={a.imageUrl} alt={a.name} width={32} height={32}/>
+                  <span>{a.name}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button className="px-2 border rounded" onClick={()=>dispatch(removeAccessory({accessoryId:a.id}))}>-</button>
+                  <span>{count(a.id)}</span>
+                  <button className="px-2 border rounded" onClick={()=>dispatch(addAccessory({accessoryId:a.id}))}>+</button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+      <div className="pt-4">
+        <button
+          className="w-full py-2 rounded text-white disabled:opacity-50"
+          style={{background:'var(--brand-red)'}}
+          disabled={!isComplete}
+          onClick={()=>alert('PDF будет в Спринте 3')}
+        >
+          {t('download')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/features/builder/builderSlice.ts
+++ b/features/builder/builderSlice.ts
@@ -1,9 +1,17 @@
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction, nanoid } from '@reduxjs/toolkit';
 import type { BuildState, ModuleSpec, Turn } from '@/packages/rules';
 import { dirToRot, advanceVec, rotateDir, computeTotals, isComplete } from '@/packages/rules';
 
 type SpecsMap = Record<string, ModuleSpec>;
-const initialState: BuildState = {
+
+export interface FreeItem { id: string; accessoryId: string; x: number; y: number; }
+
+interface BuilderState extends BuildState {
+  freeItems: FreeItem[];
+  fitToView: number;
+}
+
+const initialState: BuilderState = {
   modelId: 'dakota-s',
   chain: [],
   dir: 'E',
@@ -12,6 +20,8 @@ const initialState: BuildState = {
   totalSize: {width:0, depth:0},
   totalSeats: 0,
   isComplete: false,
+  freeItems: [],
+  fitToView: 0,
 };
 
 const slice = createSlice({
@@ -19,6 +29,18 @@ const slice = createSlice({
   initialState,
   reducers: {
     reset: () => initialState,
+    selectModel: (state, action: PayloadAction<string>) => {
+      state.modelId = action.payload;
+      state.chain = [];
+      state.dir = 'E';
+      state.cursor = {x:0,y:0};
+      state.placed = [];
+      state.totalSize = {width:0, depth:0};
+      state.totalSeats = 0;
+      state.isComplete = false;
+      state.freeItems = [];
+      state.fitToView++;
+    },
     addModule: (state, action: PayloadAction<{spec: ModuleSpec; specs: SpecsMap;}>) => {
       const spec = action.payload.spec;
       // поставить модуль
@@ -36,22 +58,48 @@ const slice = createSlice({
       state.totalSize = {width, depth};
       state.totalSeats = seats;
       state.isComplete = isComplete(state, action.payload.specs);
+      state.fitToView++;
     },
     undo: (state, action: PayloadAction<{specs: SpecsMap}>) => {
       if (state.chain.length === 0) return;
       state.chain.pop();
-      state.placed.pop();
-      // для простоты сбросим курс/курсор и пересоберём позже (v1)
-      state.dir = 'E'; state.cursor = {x:0,y:0};
-      // TODO: пересчитать dir/cursor заново по chain (достаточно переиграть addModule в цикле)
+      state.dir = 'E';
+      state.cursor = {x:0,y:0};
+      state.placed = [];
+      for (const id of state.chain) {
+        const spec = action.payload.specs[id];
+        const rotation = dirToRot(state.dir);
+        state.placed.push({ moduleId: id, x: state.cursor.x, y: state.cursor.y, rotation });
+        const {dx, dy} = advanceVec(state.dir, spec.bbox.width);
+        state.cursor.x += dx; state.cursor.y += dy;
+        const t = (spec.turn ?? 0) as Turn;
+        state.dir = rotateDir(state.dir, t);
+      }
       const {width, depth, seats} = computeTotals(state.placed, action.payload.specs);
       state.totalSize = {width, depth};
       state.totalSeats = seats;
       state.isComplete = isComplete(state, action.payload.specs);
-    }
+      state.fitToView++;
+    },
+    addAccessory: (state, action: PayloadAction<{accessoryId: string}>) => {
+      state.freeItems.push({ id: nanoid(), accessoryId: action.payload.accessoryId, x: 0, y: 0 });
+    },
+    removeAccessory: (state, action: PayloadAction<{accessoryId: string}>) => {
+      for (let i = state.freeItems.length - 1; i >= 0; i--) {
+        if (state.freeItems[i].accessoryId === action.payload.accessoryId) {
+          state.freeItems.splice(i, 1);
+          break;
+        }
+      }
+    },
+    moveAccessory: (state, action: PayloadAction<{id:string;x:number;y:number}>) => {
+      const item = state.freeItems.find(f => f.id === action.payload.id);
+      if (item) { item.x = action.payload.x; item.y = action.payload.y; }
+    },
+    fitToView: (state) => { state.fitToView++; }
   }
 });
 
-export const { reset, addModule, undo } = slice.actions;
+export const { reset, selectModel, addModule, undo, addAccessory, removeAccessory, moveAccessory, fitToView } = slice.actions;
 export default slice.reducer;
 

--- a/features/hooks.ts
+++ b/features/hooks.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux';
+import type { RootState, AppDispatch } from './store';
+
+export const useAppDispatch = () => useDispatch<AppDispatch>();
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;

--- a/features/store.ts
+++ b/features/store.ts
@@ -1,0 +1,11 @@
+import { configureStore } from '@reduxjs/toolkit';
+import builderReducer from './builder/builderSlice';
+
+export const store = configureStore({
+  reducer: {
+    builder: builderReducer,
+  },
+});
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;

--- a/lib/i18n.ts
+++ b/lib/i18n.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function useI18n(lang: string){
+  const [dict, setDict] = useState<Record<string,string>>({});
+  useEffect(() => {
+    let ignore = false;
+    fetch(`/i18n/${lang}.json`).then(r => r.json()).then(d => {
+      if(!ignore) setDict(d);
+    }).catch(()=>setDict({}));
+    return () => { ignore = true; };
+  }, [lang]);
+  const t = (key: string) => dict[key] ?? key;
+  return { t };
+}

--- a/tests/builderSlice.test.ts
+++ b/tests/builderSlice.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { configureStore } from '@reduxjs/toolkit';
+import reducer, { addModule, undo } from '@/features/builder/builderSlice';
+import modules from '@/public/mock/modules.json';
+import type { ModuleSpec } from '@/packages/rules';
+
+const mods = modules as ModuleSpec[];
+const modulesById = Object.fromEntries(mods.map(m=>[m.id,m]));
+
+describe('builder slice', () => {
+  it('completes after left and right sections', () => {
+    const store = configureStore({reducer:{builder:reducer}});
+    store.dispatch(addModule({spec: modulesById['ksl_2'], specs: modulesById}));
+    store.dispatch(addModule({spec: modulesById['ksr_2'], specs: modulesById}));
+    const state = store.getState().builder;
+    expect(state.isComplete).toBe(true);
+  });
+
+  it('corner needs right cap to complete', () => {
+    const store = configureStore({reducer:{builder:reducer}});
+    store.dispatch(addModule({spec: modulesById['ksl_2'], specs: modulesById}));
+    store.dispatch(addModule({spec: modulesById['corner_l'], specs: modulesById}));
+    let state = store.getState().builder;
+    expect(state.isComplete).toBe(false);
+    store.dispatch(addModule({spec: modulesById['ksr_2'], specs: modulesById}));
+    state = store.getState().builder;
+    expect(state.isComplete).toBe(true);
+  });
+
+  it('undo recalculates chain and totals', () => {
+    const store = configureStore({reducer:{builder:reducer}});
+    store.dispatch(addModule({spec: modulesById['ksl_2'], specs: modulesById}));
+    store.dispatch(addModule({spec: modulesById['ksr_2'], specs: modulesById}));
+    store.dispatch(undo({specs: modulesById}));
+    const state = store.getState().builder;
+    expect(state.chain.length).toBe(1);
+    expect(state.isComplete).toBe(false);
+    expect(state.totalSeats).toBe(modulesById['ksl_2'].seatCount);
+  });
+});


### PR DESCRIPTION
## Summary
- implement full builder slice with model switching, accessories, undo and fit-to-view triggers
- add UI components and data loading to build interactive configurator
- cover completion and undo scenarios with builder slice tests

## Testing
- `pnpm test run`

## Checklist
- [x] Карусель меняет модель и сбрасывает конфигурацию.
- [x] Сетка показывает только доступные модули по правилам.
- [x] Добавление модулей обновляет сцену, размеры, места.
- [x] Угловой модуль поворачивает курс на 90°.
- [x] Отмена работает, подсказки статуса появляются.
- [x] Аксессуары добавляются и перетаскиваются, не влияют на размеры/завершённость.
- [x] «Скачать» активна только при isComplete.
- [x] Макет без скролла на 1366×768+, бренд‑цвета/шрифт соблюдены.


------
https://chatgpt.com/codex/tasks/task_e_68a610ce06c08322bc8e673d9de5adb3